### PR TITLE
Upgrade lodash to latest 4.x version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,111 @@
+{
+    "name": "nemo-page",
+    "version": "1.1.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "async": {
+            "version": "0.9.2",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/async/-/async-0.9.2.tgz",
+            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "glob": {
+            "version": "5.0.15",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/glob/-/glob-5.0.15.tgz",
+            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+            "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "selenium-drivex": {
+            "version": "1.0.14",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/selenium-drivex/-/selenium-drivex-1.0.14.tgz",
+            "integrity": "sha1-FWq2/TzU25uAiCHY6fe8I0RfEKI=",
+            "requires": {
+                "async": "^0.9.0",
+                "debug": "^2.1.2"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.paypalcorp.com/artifactory/api/npm/npm-all/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nemo-page",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "View Interface for nemo enhanced with nested locators and collection mechanics.",
     "main": "index.js",
     "registerAs": "page",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "debug": "^2.1.0",
         "glob": "^5.0.3",
-        "lodash": "^3.4.0",
+        "lodash": "^4.17.21",
         "selenium-drivex": "^1.0.11"
     },
     "devDependencies": {},


### PR DESCRIPTION
Lodash 3 has [many security vulnerabilities](https://snyk.io/vuln/npm:lodash). To address these security concerns, this PR upgrades it to the latest 4.x version. Didn't see any tests in the repo, so I checked all the lodash methods used in this package – that's:

```javascript
_.clone
_.defaults
_.each
_.extend
_.isEmpty
_.isNumber
_.isString
_.isUndefined
_.template
```

against the [lodash changelog](https://github.com/lodash/lodash/wiki/Changelog) for any breaking changes in each function, and I didn't find any. PR also adds a package-lock.json file.